### PR TITLE
fix(filter): IRENT-1503 added a separate field type for person

### DIFF
--- a/src/controls/ValueEditor.tsx
+++ b/src/controls/ValueEditor.tsx
@@ -301,7 +301,7 @@ const ValueEditor: React.FC<ValueEditorProps> = (props) => {
     case 'radio':
       return renderRadio(props);
     case 'textarea':
-      case 'person':
+    case 'person':
     case 'custom': {
       const key = (field && getSelectionKey?.(field)) || 'id';
       if (customRenderer)

--- a/src/controls/ValueEditor.tsx
+++ b/src/controls/ValueEditor.tsx
@@ -301,6 +301,7 @@ const ValueEditor: React.FC<ValueEditorProps> = (props) => {
     case 'radio':
       return renderRadio(props);
     case 'textarea':
+      case 'person':
     case 'custom': {
       const key = (field && getSelectionKey?.(field)) || 'id';
       if (customRenderer)

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -26,7 +26,7 @@ export interface RuleGroupType {
 }
 export declare type ExportFormat = 'json' | 'sql' | 'json_without_ids' | 'parameterized';
 export declare type ValueProcessor = (field: string, operator: string, value: any) => string;
-export declare type ValueEditorType = 'text' | 'textarea' | 'select' | 'checkbox' | 'radio' | 'autocomplete' | 'none' | 'date' | 'custom' | 'numeric';
+export declare type ValueEditorType = 'text' | 'textarea' | 'select' | 'checkbox' | 'radio' | 'autocomplete' | 'none' | 'date' | 'custom' | 'numeric' | 'person';
 export interface CommonProps {
     /**
      * CSS classNames to be applied
@@ -173,7 +173,7 @@ export interface Schema {
     createRuleGroup(): RuleGroupType;
     getLevel(id: string): number;
     getOperators(field: string, isParent?: boolean, parentOperator?: string): Field[];
-    getValueEditorType(field: string, operator: string, parentOperator?: string): 'text' | 'select' | 'checkbox' | 'radio' | 'autocomplete' | 'date' | 'numeric' | 'custom';
+    getValueEditorType(field: string, operator: string, parentOperator?: string): 'text' | 'select' | 'checkbox' | 'radio' | 'autocomplete' | 'date' | 'numeric' | 'custom' | 'textarea'| 'person';
     getPlaceHolder(field: string, operator: string): string;
     getInputType(field: string, operator: string): string;
     getValues(field: string, operator: string): NameLabelPair[];
@@ -287,7 +287,7 @@ export interface QueryGeneratorProps {
      * This is a callback function invoked to get the type of `ValueEditor`
      * for the given field and operator.
      */
-    getValueEditorType?(field: string, operator: string, parentOperator?: string): 'text' | 'select' | 'checkbox' | 'radio' | 'date' | 'custom';
+    getValueEditorType?(field: string, operator: string, parentOperator?: string): 'text' | 'select' | 'checkbox' | 'radio' | 'date' | 'custom' | 'person';
     /**
      * This is a callback function invoked to get the `type` of `<input />`
      * for the given field and operator (only applicable when


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR introduces a new 'person' type to the ValueEditorType. This new type is added to the ValueEditor component and is also reflected in the type definitions and interfaces where ValueEditorType is used.

___
## PR Main Files Walkthrough:
`src/controls/ValueEditor.tsx`: Added 'person' as a new case in the switch statement that determines the type of ValueEditor to render.
`types/types.d.ts`: Updated the ValueEditorType declaration to include 'person'. Also, updated the getValueEditorType method in the Schema and QueryGeneratorProps interfaces to return 'person' as a possible type.
