### PR TITLE
fix(Filter): Console error on click the select date in filter for date measure XPS-29150

### DIFF
--- a/src/QueryBuilder.tsx
+++ b/src/QueryBuilder.tsx
@@ -690,7 +690,7 @@ const useQueryBuilderProps = (
 const getValueOnPropChange = (value: any, rule: RuleType, prop: string) => {
   const isValueProp = prop === 'value';
   const isLastUpdatedField = rule.field === fieldNames.LAST_UPDATED_BY && isValueProp; // ensuring updated value is valid only on value change and not other prop change
-  const isPersonField: boolean = isValueProp && typeof value === 'object' && 'id' in value;
+  const isPersonField: boolean = isValueProp && value !== null && typeof value === 'object' && 'id' in value;
   let updateValue = value;
   if (isLastUpdatedField) {
     updateValue = value[keyNames.LABEL] || updateValue;


### PR DESCRIPTION
## **Type**
bug_fix


___

## **Description**
- Fixed an issue where selecting a date in the filter for a date measure would cause a console error. This was achieved by enhancing the null check for the `value` variable in the `getValueOnPropChange` function within `QueryBuilder.tsx`.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>QueryBuilder.tsx</strong><dd><code>Fix Console Error on Select Date in Filter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/QueryBuilder.tsx
<li>Improved null check for <code>value</code> in <code>getValueOnPropChange</code> function to <br>prevent console errors.<br>


</details>
    

  </td>
  <td><a href="https://github.com/visualbis/react-querybuilder/pull/102/files#diff-5e12153b2bf6b669a58fc37fe5c10fd5afeee46051817bb2c67757cf3111f6c4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

