### PR TITLE
fix(Forecast): The selection is retaining after deleting the forecast measure IRENT-3652

### DIFF
--- a/src/controls/ValueEditor.tsx
+++ b/src/controls/ValueEditor.tsx
@@ -146,6 +146,10 @@ const renderAutoComplete = (props) => {
   else{
     showValue = value
   }
+  const isValidValue = options.find(option =>  option?.value === showValue)
+  if(!isValidValue){
+    showValue = ''
+  }
   const onChange = (val) => handleOnChange(val);
   return (
     <Autocomplete


### PR DESCRIPTION
## **Type**
bug_fix


___

## **Description**
- Fixes an issue where invalid selections were retained in the `ValueEditor`'s autocomplete component.
- Ensures that `showValue` is reset to an empty string if the selected value is not among the valid options.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ValueEditor.tsx</strong><dd><code>Fix Invalid Selection Retention in Autocomplete</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/controls/ValueEditor.tsx
<li>Added validation to ensure <code>showValue</code> is set to an empty string if it's <br>not a valid option.<br> <li> This change prevents retaining invalid selections in the autocomplete <br>component.<br>


</details>
    

  </td>
  <td><a href="https://github.com/visualbis/react-querybuilder/pull/104/files#diff-a3ccd3584398cd458f70b7a04493d54dfc4b27a18da1425479c0b55d6028171c">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

