### PR TITLE
fix(lint): too many line issues

### DIFF
--- a/src/Rule.tsx
+++ b/src/Rule.tsx
@@ -169,52 +169,42 @@ export const Rule: React.FC<RuleProps> = ({
         'singleDate',
         'dateRange',
     ];
+    const generalProps =  { 
+        controls,
+        translations,
+        classNames,
+        level,
+        field };
     return (
         <div className={`rule ${classNames.rule}`} data-rule-id={id} data-level={level}>
             {removeIconatStart && renderRemoveRuleAction({ controls, translations, classNames, removeRule, level })}
             {renderFieldSelector({
-                controls,
-                translations,
-                classNames,
+                ...generalProps,
                 fields,
-                level,
-                field,
                 operator,
                 onFieldChanged,
             })}
             {enableParentOperaton &&
                 renderParentOperatorSelector({
-                    controls,
-                    translations,
-                    classNames,
+                    ...generalProps,
                     fieldData,
-                    level,
-                    field,
                     parentOpertators,
                     parentOperator,
                     onParentOperatorChanged,
                 })}
             {!enableParentOperaton &&
                 renderOperatorSelector({
-                    controls,
-                    translations,
-                    classNames,
+                    ...generalProps,
                     fieldData,
-                    level,
-                    field,
                     getOperatorsList,
                     operator,
                     onOperatorChanged,
                 })}
             {renderValueEditor({
-                controls,
-                translations,
-                classNames,
+                ...generalProps,
                 onValueChanged,
-                field,
                 customRenderer,
                 getSelectionKey,
-                level,
                 fieldData,
                 operator: parentOperator === 'dateRange' || parentOperator === 'singleDate' ? parentOperator : operator,
                 getValueEditorType,
@@ -226,20 +216,16 @@ export const Rule: React.FC<RuleProps> = ({
                 parentOperator,
             })}
 
-            {!dateRestrictedOperators.includes(parentOperator) &&
+            {!dateRestrictedOperators.includes(parentOperator as string) &&
                 enableParentOperaton &&
                 renderOperatorSelector({
-                    controls,
-                    translations,
-                    classNames,
+                    ...generalProps,
                     fieldData,
-                    level,
-                    field,
                     getOperatorsList,
                     operator,
                     onOperatorChanged,
                 })}
-            {!removeIconatStart && renderRemoveRuleAction({ controls, translations, classNames, removeRule, level })}
+            {!removeIconatStart && renderRemoveRuleAction({  ...generalProps,removeRule, level })}
         </div>
     );
 };


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Introduced a new variable `generalProps` to hold common properties (`controls`, `translations`, `classNames`, `level`, `field`) used across multiple component renderings within the `Rule` component. This change leads to a cleaner and more maintainable codebase.
- Utilized the spread operator to pass `generalProps` to components, significantly reducing redundancy and improving code readability.
- Corrected a type assertion issue by casting `parentOperator` to `string` when checking against `dateRestrictedOperators`, ensuring type safety.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Rule.tsx</strong><dd><code>Refactor Rule Component for Cleaner Prop Passing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Rule.tsx
<li>Introduced <code>generalProps</code> to consolidate common properties passed to <br>multiple components.<br> <li> Simplified the passing of props by using the spread operator with <br><code>generalProps</code>.<br> <li> Fixed type assertion issue with <code>dateRestrictedOperators.includes</code>.


</details>
    

  </td>
  <td><a href="https://github.com/visualbis/react-querybuilder/pull/105/files#diff-2db0eb2718f7e5aab0165d34ed627946123b52815b2e712f2a25962be7146720">+13/-27</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

