### PR TITLE
fix(lint): type issue

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -194,7 +194,7 @@ export interface Schema {
   getLevel(id: string): number;
   getOperators(field: string, isParent?: boolean, parentOperator?: string): Field[];
   getValueEditorType(field: string, operator: string, parentOperator?: string): 'text' | 'select' | 'checkbox' | 'radio' | 'autocomplete' | 'date' | 'numeric' | 'custom' | 'person';
-  getPlaceHolder(field: string, operator: string): string;
+  getPlaceHolder(field: string, operator: string, parentOperator: string): string;
   getInputType(field: string, operator: string): string;
   getValues(field: string, operator: string): NameLabelPair[];
   isRuleGroup(ruleOrGroup: RuleType | RuleGroupType): ruleOrGroup is RuleGroupType;


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Extended the `getPlaceHolder` method in `Schema` interface to include an additional parameter `parentOperator`. This enhancement allows for more flexible placeholder text generation based on both the operator and the parent operator context.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>types.ts</strong><dd><code>Extend `getPlaceHolder` Method Signature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/types.ts
<li>Added <code>parentOperator</code> parameter to <code>getPlaceHolder</code> method signature.<br>


</details>
    

  </td>
  <td><a href="https://github.com/visualbis/react-querybuilder/pull/106/files#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

