### PR TITLE
fix(variables): n Flexi filter, the selected variable name is not displayed. XPS-29426

### DIFF
--- a/src/controls/ValueEditor.tsx
+++ b/src/controls/ValueEditor.tsx
@@ -146,6 +146,10 @@ const renderAutoComplete = (props) => {
   else{
     showValue = value
   }
+  const isValidValue = options.find(option =>  option?.value === showValue)
+  if(!isValidValue){
+    showValue = ''
+  }
   const onChange = (val) => handleOnChange(val);
   return (
     <Autocomplete

--- a/src/controls/ValueEditor.tsx
+++ b/src/controls/ValueEditor.tsx
@@ -147,7 +147,7 @@ const renderAutoComplete = (props) => {
     showValue = value
   }
   const isValidValue = options.find(option =>  option?.value === showValue)
-  if(!isValidValue){
+  if(!isValidValue && !hasCalcVariable){
     showValue = ''
   }
   const onChange = (val) => handleOnChange(val);


### PR DESCRIPTION
## **Type**
bug_fix


___

## **Description**
- Fixes an issue where invalid selected values were displayed in the Value Editor.
- Ensures that the displayed value is cleared if it is not valid and there is no calculation variable present.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ValueEditor.tsx</strong><dd><code>Ensure Valid Selection in Value Editor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/controls/ValueEditor.tsx
<li>Added a check to ensure the selected value is valid based on available <br>options.<br> <li> Clears the displayed value if it's not valid and there's no <br>calculation variable.<br>


</details>
    

  </td>
  <td><a href="https://github.com/visualbis/react-querybuilder/pull/107/files#diff-a3ccd3584398cd458f70b7a04493d54dfc4b27a18da1425479c0b55d6028171c">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

