### PR TITLE
fix(Variables): In Flexi filter, the selected variable name is not displayed. XPS-29426, XPS-29472 & XPS-29468

### DIFF
--- a/src/controls/ValueEditor.tsx
+++ b/src/controls/ValueEditor.tsx
@@ -147,7 +147,7 @@ const renderAutoComplete = (props) => {
     showValue = value
   }
   const isValidValue = options.find(option =>  option?.value === showValue)
-  if(!isValidValue){
+  if(!isValidValue && !hasCalcVariable){
     showValue = ''
   }
   const onChange = (val) => handleOnChange(val);


### PR DESCRIPTION
## **Type**
bug_fix


___

## **Description**
- Fixes an issue in `ValueEditor` where the selected variable name was not displayed if it was not found in the options list and `hasCalcVariable` was not considered.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ValueEditor.tsx</strong><dd><code>Fix Variable Display Issue in ValueEditor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/controls/ValueEditor.tsx
<li>Added a condition to check for <code>hasCalcVariable</code> before resetting <br><code>showValue</code> to an empty string.<br>


</details>
    

  </td>
  <td><a href="https://github.com/visualbis/react-querybuilder/pull/108/files#diff-a3ccd3584398cd458f70b7a04493d54dfc4b27a18da1425479c0b55d6028171c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

