### PR TITLE
feat(Drill Down) : Disabled Advanced filter for Performance Build XPS-27939

### DIFF
--- a/src/QueryBuilder.tsx
+++ b/src/QueryBuilder.tsx
@@ -151,7 +151,8 @@ export const QueryBuilder: React.FC<QueryBuilderProps> = ({
   removeIconatStart = false,
   customRenderer,
   getSelectionKey,
-  onSaveFilter
+  enableDrilldown = false,
+  onSaveFilter,
 }) => {
   const getInitialQuery = () => {
     // Gets the initial query
@@ -256,7 +257,8 @@ export const QueryBuilder: React.FC<QueryBuilderProps> = ({
     showNotToggle,
     removeIconatStart,
     customRenderer,
-    getSelectionKey
+    getSelectionKey,
+    enableDrilldown,
   };
   useEffect(() => {
     // Set the query state when a new query prop comes in
@@ -307,7 +309,7 @@ export const QueryBuilder: React.FC<QueryBuilderProps> = ({
           />
         )}
       </div>
-      {enableNormalView && (
+      {enableNormalView && !enableDrilldown && (
         <div className="queryBuilder-footerAdvanced">
           <div
             title="Open advanced filter"

--- a/src/QueryGenerator.tsx
+++ b/src/QueryGenerator.tsx
@@ -22,6 +22,7 @@ export interface IProps {
   customRenderer?(): any;
   getSelectionKey?(field: string): string;
   saveFilter?(): void;
+  enableDrilldown ? :boolean
 }
 
 export const QueryGenerator: React.FC<IProps> = ({
@@ -41,7 +42,8 @@ export const QueryGenerator: React.FC<IProps> = ({
   onAdvancedClick,
   getSelectedColumn,
   customRenderer,
-  getSelectionKey
+  getSelectionKey,
+  enableDrilldown
 }) => {
   const generatorCls = !showAddGroup ? `query-generator hide-group` : 'query-generator';
   return (
@@ -66,6 +68,7 @@ export const QueryGenerator: React.FC<IProps> = ({
         getSelectedColumn={getSelectedColumn}
         customRenderer={customRenderer}
         getSelectionKey={getSelectionKey}
+        enableDrilldown = {enableDrilldown}
       />
     </div>
   );


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Introduced a new `enableDrilldown` prop in both `QueryBuilder` and `QueryGenerator` components to control the visibility and functionality of the advanced filter in the UI.
- This change allows for conditional rendering of the advanced filter based on the `enableDrilldown` flag, enhancing the flexibility of the UI components.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>QueryBuilder.tsx</strong><dd><code>Add Drilldown Feature Control</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/QueryBuilder.tsx
<li>Added <code>enableDrilldown</code> prop to control the visibility of the advanced <br>filter.<br> <li> Modified footer to conditionally render based on <code>enableDrilldown</code> prop.<br> <br>


</details>
    

  </td>
  <td><a href="https://github.com/visualbis/react-querybuilder/pull/109/files#diff-5e12153b2bf6b669a58fc37fe5c10fd5afeee46051817bb2c67757cf3111f6c4">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>QueryGenerator.tsx</strong><dd><code>Implement Drilldown Feature Toggle</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/QueryGenerator.tsx
<li>Introduced <code>enableDrilldown</code> prop to manage drilldown feature.<br> <li> Passed <code>enableDrilldown</code> prop to child components to control feature <br>availability.<br>


</details>
    

  </td>
  <td><a href="https://github.com/visualbis/react-querybuilder/pull/109/files#diff-35b0084b873e463b55a100d3c959ccb3b90e049a400824df089dde8e920471b4">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

