### PR TITLE
feat(range-date-picker-added): XPS-29743

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@visualbi/react-querybuilder",
-  "version": "0.0.85",
+  "version": "0.0.86",
   "description": "The React <QueryBuilder /> component for constructing queries",
   "main": "dist/",
   "types": "types/index.d.ts",

--- a/src/Rule.tsx
+++ b/src/Rule.tsx
@@ -216,7 +216,7 @@ export const Rule: React.FC<RuleProps> = ({
                 parentOperator,
             })}
 
-            {!dateRestrictedOperators.includes(parentOperator as string) &&
+            {!['datePeriods'].includes(parentOperator) && !dateRestrictedOperators.includes(parentOperator as string) &&
                 enableParentOperaton &&
                 renderOperatorSelector({
                     ...generalProps,

--- a/src/controls/ValueEditor.tsx
+++ b/src/controls/ValueEditor.tsx
@@ -306,7 +306,8 @@ const ValueEditor: React.FC<ValueEditorProps> = (props) => {
       return renderRadio(props);
     case 'textarea':
     case 'person':
-    case 'custom': {
+    case 'custom': 
+    case 'datePeriods': {
       const key = (field && getSelectionKey?.(field)) || 'id';
       if (customRenderer)
         return customRenderer({


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Added support for custom rendering of 'datePeriods' in `ValueEditor.tsx`.
- Enhanced the operator selection logic in `Rule.tsx` to exclude 'datePeriods' from date-restricted operators, allowing for more flexible rule configurations.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Rule.tsx</strong><dd><code>Enhance Operator Selection Logic for Date Periods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Rule.tsx
<li>Added a condition to exclude 'datePeriods' from <br>dateRestrictedOperators.<br> <li> Ensured <code>renderOperatorSelector</code> is called when <code>enableParentOperation</code> is <br>true and the operator is not restricted.<br>


</details>
    

  </td>
  <td><a href="https://github.com/visualbis/react-querybuilder/pull/111/files#diff-2db0eb2718f7e5aab0165d34ed627946123b52815b2e712f2a25962be7146720">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ValueEditor.tsx</strong><dd><code>Support Custom Rendering for Date Periods in Value Editor</code></dd></summary>
<hr>

src/controls/ValueEditor.tsx
<li>Added 'datePeriods' case in switch statement to handle custom <br>rendering.<br> <li> Utilizes <code>customRenderer</code> if available for 'datePeriods'.<br>


</details>
    

  </td>
  <td><a href="https://github.com/visualbis/react-querybuilder/pull/111/files#diff-a3ccd3584398cd458f70b7a04493d54dfc4b27a18da1425479c0b55d6028171c">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

