### PR TITLE
fix(filter): UI changes AB#74297

### DIFF
--- a/src/RuleGroup.tsx
+++ b/src/RuleGroup.tsx
@@ -9,9 +9,10 @@ interface RulesRendererProps{
   level:number,
   schema:Schema,
   id:string
+  enableClear:boolean
 
 }
-export const RuleGroup: React.FC<RuleGroupProps> = ({ id, combinator = 'and',  rules = [],  translations,  schema,parentId   }) => {
+export const RuleGroup: React.FC<RuleGroupProps> = ({ id, combinator = 'and',  rules = [],  translations,  schema,parentId ,enableClear =false }) => {
   const { classNames, hasColumnChildRule, combinators, controls, createRule, createRuleGroup, getLevel,  onGroupAdd,  onPropChange, onRuleAdd, showCombinatorsBetweenRules, showAddGroup,showAddRule, customRenderer,onGroupRemove} = schema;
   const onCombinatorChange = (value: any) => {
     onPropChange('combinator', value, id);
@@ -38,10 +39,10 @@ const onRemoveGroup=(event)=>{
   onGroupRemove(id, parentId ||"")
 }
   return (<div
-        className={`ruleGroup ${classNames.ruleGroup} rule-group-connect ${level==0?'ruleGroupFirst':null}` }
+        className={`ruleGroup ${classNames.ruleGroup} ${!enableClear?'rule-group-connect':null} ${level==0&& !enableClear?'ruleGroupFirst':null}` }
         data-rule-group-id={id}
         data-level={level}>
-        {level > 0 && (
+        {level > 0 && !enableClear &&(
           <RuleGroupHeader level={level} onRemoveGroup={onRemoveGroup}/>
         )}
         {((!showCombinatorsBetweenRules && rules && rules.length > 1) ||
@@ -49,7 +50,7 @@ const onRemoveGroup=(event)=>{
           showAddRule) && (
           <div
             className={`ruleGroup-header ${classNames.header} ${
-              level === 0 ? 'ruleGroup-firstHeader' : null
+              level === 0 && !enableClear? 'ruleGroup-firstHeader' : null
             }`}>
             {!showCombinatorsBetweenRules && rules && rules.length > 1 && (
               <controls.combinatorSelector
@@ -79,7 +80,7 @@ const onRemoveGroup=(event)=>{
                 level={level}
               />
             )}
-
+            {showAddGroup && showAddRule &&<span className='add-rule-separated-line'></span>}
             {showAddRule && (
               <controls.addRuleAction
                 label={translations.addRule.label}
@@ -101,6 +102,7 @@ const onRemoveGroup=(event)=>{
           level={level}
           schema={schema}
           id={id}
+          enableClear={enableClear}
           />}
       </div>
 
@@ -109,7 +111,7 @@ const onRemoveGroup=(event)=>{
 
 const RulesRenderer=(props:RulesRendererProps)=>{
   const linkColors=['violetLink','orangeLink','greenLink','yellowLink','redLink','blueLink']
-  const{rules,combinator,translations,combinatorCls,onCombinatorChange,level,schema,id}=props
+  const{rules,combinator,translations,combinatorCls,onCombinatorChange,level,schema,id,enableClear}=props
   const {isRuleGroup,combinators,controls,classNames,showCombinatorsBetweenRules}=schema
   return <>{
     rules.map((r, idx) => (
@@ -129,7 +131,8 @@ const RulesRenderer=(props:RulesRendererProps)=>{
           </div>
         )}
         {isRuleGroup(r) ? (
-          <div className={`rule-connect-link ${rules?.length >1 ? linkColors[(level % 6)]:null }`}><RuleGroup
+          <div className={`${!enableClear && 'rule-connect-link'}
+             ${rules?.length >1 && !enableClear ? linkColors[(level % 6)]:null }`}><RuleGroup
           id={r.id}
           schema={schema}
           parentId={id}
@@ -139,7 +142,7 @@ const RulesRenderer=(props:RulesRendererProps)=>{
           not={!!r.not}
         /></div>
         ) : r.id ? (
-          <div className={`rule-connect-link ${rules?.length >1? linkColors[(level % 6)]:null }`}><controls.rule
+          <div className={`${!enableClear&&'rule-connect-link'} ${rules?.length>1&& !enableClear? linkColors[(level % 6)]:null }`}><controls.rule
           id={r.id}
           field={r.field}
           value={r.value}

--- a/src/query-builder.less
+++ b/src/query-builder.less
@@ -918,9 +918,8 @@
 }
 
 .ruleGroup {
-  background: @color1;
   border: 1px solid @color0;
-  padding: 2px;
+  padding: 2px 0;
 
   .ruleGroup-combinators.betweenRules {
     margin: 10px;
@@ -934,9 +933,7 @@
   }
 
   .ruleGroup {
-    background: @color1;
     margin: 5px;
-    padding: 5px;
   }
 }
 
@@ -960,7 +957,7 @@
   .queryBuilder {
     max-height: 500px;
     max-width: 500px;
-    overflow-x: hidden;
+    overflow-x: auto;
     overflow-y: auto;
     margin: 5px;
     border: 1px solid #cccccc;
@@ -980,6 +977,7 @@
 .ruleGroup-header {
   display: flex;
   margin: 0px 5px;
+  align-items: center;
 
   .ruleGroup-addGroup {
     background: @color1;
@@ -998,6 +996,11 @@
       padding: 5px 15px;
     }
   }
+
+  .add-rule-separated-line {
+    border-left: 1px solid #dddddd;
+    height: 18px;
+  }
 }
 
 .ruleGroup-addRule {
@@ -1006,7 +1009,6 @@
   color: @color2;
   margin-left: 5px;
   outline: none;
-  padding: 5px 15px;
 
   &:focus {
     background: @color1;
@@ -1224,8 +1226,10 @@
 
 .ruleGroupFirst {
   margin-top: 0;
-  border-top: 0;
+  border: none;
   padding-top: 0;
+  width: fit-content;
+  min-width: 100%;
 }
 
 .ruleGroup-firstHeader {
@@ -1244,6 +1248,7 @@
 .ruleGroup .ruleGroup-title {
   display: flex;
   justify-content: space-between;
+  min-width: 350px;
 
   .group-filter-title-content {
     display: flex;
@@ -1253,6 +1258,7 @@
     .group-filter-icon,
     .group-filter-title {
       padding: 0 5px;
+      font-size: 12px;
     }
 
     .group-filter-icon {


### PR DESCRIPTION
### **User description**
Changes restricted for normal filter.
some styling issues are fixed.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added `enableClear` prop to `RuleGroup` and `RulesRenderer` components to control conditional rendering and styling.
- Adjusted CSS styles for `.ruleGroup`, `.query-generator`, `.ruleGroup-header`, and other related classes.
- Fixed styling issues related to padding, margin, and alignment.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RuleGroup.tsx</strong><dd><code>Add `enableClear` prop and conditional rendering logic.</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/RuleGroup.tsx
<li>Added <code>enableClear</code> prop to <code>RuleGroup</code> and <code>RulesRenderer</code>.<br> <li> Conditional rendering adjustments based on <code>enableClear</code>.<br> <li> Updated class names and styles conditionally.<br>


</details>
    

  </td>
  <td><a href="https://github.com/visualbis/react-querybuilder/pull/118/files#diff-2d42acb42590621341574a01aec32042315c5f8deb97cc8b25fbbc2f75f038fe">+11/-8</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>query-builder.less</strong><dd><code>Update styles for rule group and query generator components.</code></dd></summary>
<hr>

src/query-builder.less
<li>Adjusted padding and margin for <code>.ruleGroup</code>.<br> <li> Added <code>.add-rule-separated-line</code> style.<br> <li> Modified styles for <code>.query-generator</code> and <code>.ruleGroup-header</code>.<br> <li> Updated styles for <code>.ruleGroupFirst</code> and <code>.ruleGroup-title</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/visualbis/react-querybuilder/pull/118/files#diff-6672ef5f9e3e31c821f4f3efa891bb3c3fef810334e11f8d80e9c34a532c1d30">+13/-7</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

