### PR TITLE
fix(filters): not able to type values in the filter Fixed AB#82854

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@visualbi/react-querybuilder",
-  "version": "0.0.92",
+  "version": "0.0.93",
   "description": "The React <QueryBuilder /> component for constructing queries",
   "main": "dist/",
   "types": "types/index.d.ts",

--- a/src/controls/ValueEditor.tsx
+++ b/src/controls/ValueEditor.tsx
@@ -146,10 +146,10 @@ const renderAutoComplete = (props) => {
   else{
     showValue = value
   }
-  const isValidValue = options.find(option =>  option?.value === showValue)
-  if(!isValidValue && !hasCalcVariable){
-    showValue = ''
-  }
+  // const isValidValue = options.find(option =>  option?.value === showValue)
+  // if(!isValidValue && !hasCalcVariable){
+  //   showValue = ''
+  // }
   const onChange = (val) => handleOnChange(val);
   return (
     <Autocomplete


### PR DESCRIPTION
### **User description**
Filters not able to type values


___

### **PR Type**
Bug fix


___

### **Description**
- Commented out the validation logic in `ValueEditor.tsx` that prevented typing values in the filter.
- Updated the package version in `package.json` from 0.0.92 to 0.0.93.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ValueEditor.tsx</strong><dd><code>Comment out validation logic for filter values</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/controls/ValueEditor.tsx

<li>Commented out code that checks for valid values in the options.<br> <li> Removed logic that sets <code>showValue</code> to an empty string if the value is <br>not valid and <code>hasCalcVariable</code> is false.<br>


</details>
    

  </td>
  <td><a href="https://github.com/visualbis/react-querybuilder/pull/120/files#diff-a3ccd3584398cd458f70b7a04493d54dfc4b27a18da1425479c0b55d6028171c">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Bump package version to 0.0.93</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
package.json

- Updated the package version from 0.0.92 to 0.0.93.



</details>
    

  </td>
  <td><a href="https://github.com/visualbis/react-querybuilder/pull/120/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

