### PR TITLE
fix(filter): Showing label instead of underlying value fix AB#104856  AB#105317

### DIFF
--- a/src/controls/ValueEditor.tsx
+++ b/src/controls/ValueEditor.tsx
@@ -139,13 +139,14 @@ const renderAutoComplete = (props) => {
     }
   }
   const val = matches ? matches[0] : '';
-  if (hasCalcVariable || showLabel) {
+  if (hasCalcVariable) {
     options.forEach((option) => {
-      if(showLabel) {
-        if(option.value === value) showValue = option.label;
-      }
-      else if (option.value.includes(val)) showValue = option.label;
+      if (option.value.includes(val)) showValue = option.label;
     });
+  }
+  else if(showLabel){
+    const displayValue = options.find(option => option.value === value)?.label
+    showValue = displayValue ? displayValue : value
   }
   else{
     showValue = value

--- a/src/controls/ValueEditor.tsx
+++ b/src/controls/ValueEditor.tsx
@@ -128,7 +128,7 @@ const renderSelect = (props) => {
 
 const renderAutoComplete = (props) => {
   const { placeHolder, value, options, handleOnChange, className, fieldData } = props;
-  const showLabel = fieldData?.showLabel
+  const showLabel = fieldData?.showLabel;
   let matches;
   let showValue;
   const hasCalcVariable = value.includes('CALC_VARIABLE_');
@@ -143,13 +143,11 @@ const renderAutoComplete = (props) => {
     options.forEach((option) => {
       if (option.value.includes(val)) showValue = option.label;
     });
-  }
-  else if(showLabel){
-    const displayValue = options.find(option => option.value === value)?.label
-    showValue = displayValue ? displayValue : value
-  }
-  else{
-    showValue = value
+  } else if (showLabel) {
+    const displayValue = options.find((option) => option.value === value)?.label;
+    showValue = displayValue ? displayValue : value;
+  } else {
+    showValue = value;
   }
   // const isValidValue = options.find(option =>  option?.value === showValue)
   // if(!isValidValue && !hasCalcVariable){
@@ -311,7 +309,7 @@ const ValueEditor: React.FC<ValueEditorProps> = (props) => {
       return renderRadio(props);
     case 'textarea':
     case 'person':
-    case 'custom': 
+    case 'custom':
     case 'datePeriods': {
       const key = (field && getSelectionKey?.(field)) || 'id';
       if (customRenderer)


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed the logic in the `ValueEditor` component to correctly display labels instead of underlying values when `showLabel` is true.
- Adjusted the conditional checks to ensure `showValue` is set appropriately based on the presence of `hasCalcVariable` and `showLabel`.
- Improved the readability and maintainability of the code by simplifying the conditions.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ValueEditor.tsx</strong><dd><code>Fix label display logic in ValueEditor component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/controls/ValueEditor.tsx

<li>Modified logic to determine <code>showValue</code> based on <code>showLabel</code> and <br><code>hasCalcVariable</code>.<br> <li> Simplified conditionals for setting <code>showValue</code> when <code>showLabel</code> is true.<br> <li> Ensured <code>showValue</code> displays the label instead of the underlying value <br>when applicable.<br>


</details>


  </td>
  <td><a href="https://github.com/visualbis/react-querybuilder/pull/125/files#diff-a3ccd3584398cd458f70b7a04493d54dfc4b27a18da1425479c0b55d6028171c">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information